### PR TITLE
#30 Optimised byte encoding (for HBase caches)

### DIFF
--- a/geocode-api/pom.xml
+++ b/geocode-api/pom.xml
@@ -39,6 +39,10 @@
       <groupId>com.fasterxml.jackson.core</groupId>
       <artifactId>jackson-annotations</artifactId>
     </dependency>
+    <dependency>
+      <groupId>org.apache.avro</groupId>
+      <artifactId>avro</artifactId>
+    </dependency>
 
     <!-- test -->
     <dependency>
@@ -52,4 +56,30 @@
       <scope>test</scope>
     </dependency>
   </dependencies>
+  <build>
+    <plugins>
+      <plugin>
+        <groupId>org.apache.avro</groupId>
+        <artifactId>avro-maven-plugin</artifactId>
+        <version>${avro.version}</version>
+        <executions>
+          <execution>
+            <id>schemas</id>
+            <phase>generate-sources</phase>
+            <goals>
+              <goal>schema</goal>
+            </goals>
+            <configuration>
+              <sourceDirectory>${project.basedir}/src/main/avro</sourceDirectory>
+              <outputDirectory>${project.build.directory}/generated-sources/avro</outputDirectory>
+              <stringType>String</stringType>
+              <imports>
+                <import>${project.basedir}/src/main/avro/org/gbif/geocode/api/model/Location.avsc</import>
+              </imports>
+            </configuration>
+          </execution>
+        </executions>
+      </plugin>
+    </plugins>
+  </build>
 </project>

--- a/geocode-api/src/main/avro/org/gbif/geocode/api/model/Location.avsc
+++ b/geocode-api/src/main/avro/org/gbif/geocode/api/model/Location.avsc
@@ -1,0 +1,51 @@
+{
+  "namespace": "org.gbif.geocode.api.model",
+  "type": "record",
+  "name": "LocationAvro",
+  "doc": "Represents a location feature.",
+  "fields": [
+    {
+      "name": "id",
+      "type": "string"
+    },
+    {
+      "name": "id_prefix",
+      "type": ["null", {
+        "type": "enum",
+        "name": "LocationIdPrefix",
+        "namespace": "org.gbif.geocode.api.model",
+        "symbols": ["MRGID"]
+      }],
+      "default": null
+    },
+    {
+      "name": "type",
+      "type": {
+        "type": "enum",
+        "name": "LocationType",
+        "namespace": "org.gbif.geocode.api.model",
+        "symbols": ["GADM0", "GADM1", "GADM2", "GADM3", "WGSRPD", "Continent", "Political", "IHO", "Centroids"]
+      }
+    },
+    {
+      "name": "title",
+      "type": ["null", "string"],
+      "default": null
+    },
+    {
+      "name": "isoCountryCode2Digit",
+      "type": ["null", "string"],
+      "default": null
+    },
+    {
+      "name": "distance",
+      "type": ["null", "double"],
+      "default": null
+    },
+    {
+      "name": "distanceMeters",
+      "type": ["null", "double"],
+      "default": null
+    }
+  ]
+}

--- a/geocode-api/src/main/avro/org/gbif/geocode/api/model/Location.avsc
+++ b/geocode-api/src/main/avro/org/gbif/geocode/api/model/Location.avsc
@@ -41,6 +41,11 @@
       "name": "distance",
       "type": ["null", "double"],
       "default": null
+    },
+    {
+      "name": "distanceMeters",
+      "type": ["null", "double"],
+      "default": null
     }
   ]
 }

--- a/geocode-api/src/main/avro/org/gbif/geocode/api/model/Location.avsc
+++ b/geocode-api/src/main/avro/org/gbif/geocode/api/model/Location.avsc
@@ -24,7 +24,7 @@
         "type": "enum",
         "name": "LocationType",
         "namespace": "org.gbif.geocode.api.model",
-        "symbols": ["GADM0", "GADM1", "GADM2", "GADM3", "WGSRPD", "Continent", "Political", "IHO", "Centroids"]
+        "symbols": ["GADM0", "GADM1", "GADM2", "GADM3", "WGSRPD", "Continent", "Political", "IHO", "Centroids", "IUCN"]
       }
     },
     {
@@ -39,11 +39,6 @@
     },
     {
       "name": "distance",
-      "type": ["null", "double"],
-      "default": null
-    },
-    {
-      "name": "distanceMeters",
       "type": ["null", "double"],
       "default": null
     }

--- a/geocode-api/src/main/avro/org/gbif/geocode/api/model/LocationList.avsc
+++ b/geocode-api/src/main/avro/org/gbif/geocode/api/model/LocationList.avsc
@@ -1,0 +1,15 @@
+{
+  "namespace": "org.gbif.geocode.api.model",
+  "type": "record",
+  "name": "LocationList",
+  "doc": "Container for a list of locations.",
+  "fields": [
+    {
+      "name": "locations",
+      "type": {
+        "type": "array",
+        "items": "org.gbif.geocode.api.model.LocationAvro"
+      }
+    }
+  ]
+}

--- a/geocode-api/src/main/java/org/gbif/geocode/api/model/LocationEncoder.java
+++ b/geocode-api/src/main/java/org/gbif/geocode/api/model/LocationEncoder.java
@@ -1,0 +1,165 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.gbif.geocode.api.model;
+
+import com.fasterxml.jackson.core.type.TypeReference;
+import com.fasterxml.jackson.databind.JsonNode;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import java.io.ByteArrayInputStream;
+import java.io.ByteArrayOutputStream;
+import java.io.IOException;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Map;
+import org.apache.avro.io.BinaryDecoder;
+import org.apache.avro.io.BinaryEncoder;
+import org.apache.avro.io.DatumReader;
+import org.apache.avro.io.DatumWriter;
+import org.apache.avro.io.DecoderFactory;
+import org.apache.avro.io.EncoderFactory;
+import org.apache.avro.specific.SpecificDatumReader;
+import org.apache.avro.specific.SpecificDatumWriter;
+
+/**
+ * Provides an Avro encoding for the locations contained within the geocode response.
+ *
+ * <p>This exists to better compress responses specifically to allow better cache performance.
+ * The HBase block cache is an example that benefits from this.
+ *
+ * <p>Optimisations applied during encoding:
+ * <ul>
+ *   <li>The source string is dropped from the response! This is because GBIF pipelines do not require
+ *   this and it is verbose.</li>
+ *   <li>The {@code type} string is stored as a compact {@link LocationType} enum. Should new types be
+ *   added to the database, the avro schema must be changed to support it.</li>
+ *   <li>Well-known ID prefixes are stripped from {@code id} and recorded in {@code id_prefix},
+ *       saving repeated prefix bytes per record.</li>
+ * </ul>
+ */
+public class LocationEncoder {
+
+  // Optimisation: Detect common prefixes to reduce bytes. One URL per value only!
+  private static final Map<LocationIdPrefix, String> ID_PREFIX_MAP =
+    Map.of(LocationIdPrefix.MRGID, "http://marineregions.org/mrgid/");
+  private static final ObjectMapper OBJECT_MAPPER = new ObjectMapper();
+
+  private LocationEncoder() {}
+
+  /** Converts to the Avro representation. */
+  public static LocationAvro toAvro(Location location) {
+    if (location == null) return null;
+
+    LocationType typeEnum = LocationType.valueOf(location.getType());
+
+    // Optimisation: detect common prefixes
+    String id = location.getId();
+    LocationIdPrefix idPrefix = null;
+    for (Map.Entry<LocationIdPrefix, String> entry : ID_PREFIX_MAP.entrySet()) {
+      if (id != null && id.startsWith(entry.getValue())) {
+        idPrefix = entry.getKey();
+        id = id.substring(entry.getValue().length());
+        break;
+      }
+    }
+
+    return LocationAvro.newBuilder()
+      .setId(id)
+      .setIdPrefix(idPrefix)
+      .setType(typeEnum)
+      .setTitle(location.getTitle())
+      .setIsoCountryCode2Digit(location.getIsoCountryCode2Digit())
+      .setDistance(location.getDistance())
+      .setDistanceMeters(location.getDistanceMeters())
+      .build();
+  }
+
+  /** Converts from the Avro representation. */
+  public static Location fromAvro(LocationAvro locationAvro) {
+    if (locationAvro == null) {
+      return null;
+    }
+
+    String id = locationAvro.getId();
+    if (locationAvro.getIdPrefix() != null) {
+      id = ID_PREFIX_MAP.get(locationAvro.getIdPrefix()) + id;
+    }
+
+    Location location = new Location();
+    location.setId(id);
+    location.setType(locationAvro.getType().toString());
+    location.setTitle(locationAvro.getTitle());
+    location.setIsoCountryCode2Digit(locationAvro.getIsoCountryCode2Digit());
+    location.setDistance(locationAvro.getDistance());
+    location.setDistanceMeters(locationAvro.getDistanceMeters());
+    return location;
+  }
+
+  /** Converts to the Avro representation. */
+  public static LocationList toAvro(List<Location> locations) {
+    List<LocationAvro> payload = new ArrayList<>(locations.size());
+    for (Location location : locations) {
+      payload.add(toAvro(location));
+    }
+    return LocationList.newBuilder().setLocations(payload).build();
+  }
+
+
+  /** Converts from the Avro representation. */
+  public static List<Location> fromAvro(LocationList locations) {
+    if (locations == null || locations.getLocations() == null) return new ArrayList<>();
+
+    List<Location> response = new ArrayList<>();
+    for (LocationAvro location : locations.getLocations()) {
+      response.add(fromAvro(location));
+    }
+    return response;
+  }
+
+  /** Encodes the locations in Avro omitting the schema. */
+  public static byte[] encode(List<Location> locations) throws IOException {
+    LocationList avro = toAvro(locations);
+    DatumWriter<LocationList> datumWriter = new SpecificDatumWriter<>(LocationList.class);
+    try (ByteArrayOutputStream out = new ByteArrayOutputStream()) {
+      BinaryEncoder encoder = EncoderFactory.get().binaryEncoder(out, null);
+      datumWriter.write(avro, encoder);
+      encoder.flush();
+      return out.toByteArray();
+    }
+  }
+
+  /** Decodes the locations from Avro. */
+  public static List<Location> decode(byte[] data) throws IOException {
+    DatumReader<LocationList> datumReader = new SpecificDatumReader<>(LocationList.class);
+    try (ByteArrayInputStream in = new ByteArrayInputStream(data)) {
+      BinaryDecoder decoder = DecoderFactory.get().binaryDecoder(in, null);
+      LocationList avro = datumReader.read(null, decoder);
+      return fromAvro(avro);
+    }
+  }
+
+  /**
+   * A utility method that reads JSON that has been serialized as bytes and converts to the Avro representation.
+   * This is only expected to be useful to e.g. rewrite an existing cache.
+   */
+  public static byte[] encodeFromJsonBytes(byte[] json) throws IOException {
+    JsonNode root = OBJECT_MAPPER.readTree(json);
+    List<Location> locations;
+    if (root.isObject() && root.has("locations")) {
+      locations = OBJECT_MAPPER.convertValue(root.get("locations"), new TypeReference<>() {});
+    } else {
+      locations = OBJECT_MAPPER.convertValue(root, new TypeReference<>() {});
+    }
+    return encode(locations);
+  }
+}

--- a/geocode-api/src/main/java/org/gbif/geocode/api/model/LocationEncoder.java
+++ b/geocode-api/src/main/java/org/gbif/geocode/api/model/LocationEncoder.java
@@ -60,7 +60,18 @@ public class LocationEncoder {
   public static LocationAvro toAvro(Location location) {
     if (location == null) return null;
 
-    LocationType typeEnum = LocationType.valueOf(location.getType());
+    String type = location.getType();
+    if (type == null) {
+      throw new IllegalArgumentException(
+        "Location type must not be null for location id=" + location.getId());
+    }
+    LocationType typeEnum;
+    try {
+      typeEnum = LocationType.valueOf(type);
+    } catch (IllegalArgumentException e) {
+      throw new IllegalArgumentException(
+        "Unknown LocationType '" + type + "' for location id=" + location.getId(), e);
+    }
 
     // Optimisation: detect common prefixes
     String id = location.getId();
@@ -80,7 +91,6 @@ public class LocationEncoder {
       .setTitle(location.getTitle())
       .setIsoCountryCode2Digit(location.getIsoCountryCode2Digit())
       .setDistance(location.getDistance())
-      .setDistanceMeters(location.getDistanceMeters())
       .build();
   }
 
@@ -92,7 +102,14 @@ public class LocationEncoder {
 
     String id = locationAvro.getId();
     if (locationAvro.getIdPrefix() != null) {
-      id = ID_PREFIX_MAP.get(locationAvro.getIdPrefix()) + id;
+      String prefix = ID_PREFIX_MAP.get(locationAvro.getIdPrefix());
+      if (prefix == null) {
+        throw new IllegalStateException(
+          "Unknown LocationIdPrefix " + locationAvro.getIdPrefix()
+            + " when decoding LocationAvro; ID_PREFIX_MAP must be updated to match the schema."
+        );
+      }
+      id = prefix + id;
     }
 
     Location location = new Location();
@@ -101,12 +118,14 @@ public class LocationEncoder {
     location.setTitle(locationAvro.getTitle());
     location.setIsoCountryCode2Digit(locationAvro.getIsoCountryCode2Digit());
     location.setDistance(locationAvro.getDistance());
-    location.setDistanceMeters(locationAvro.getDistanceMeters());
     return location;
   }
 
   /** Converts to the Avro representation. */
   public static LocationList toAvro(List<Location> locations) {
+    if (locations == null) {
+      throw new IllegalArgumentException("locations must not be null");
+    }
     List<LocationAvro> payload = new ArrayList<>(locations.size());
     for (Location location : locations) {
       payload.add(toAvro(location));

--- a/geocode-api/src/main/java/org/gbif/geocode/api/model/LocationEncoder.java
+++ b/geocode-api/src/main/java/org/gbif/geocode/api/model/LocationEncoder.java
@@ -91,6 +91,7 @@ public class LocationEncoder {
       .setTitle(location.getTitle())
       .setIsoCountryCode2Digit(location.getIsoCountryCode2Digit())
       .setDistance(location.getDistance())
+      .setDistanceMeters(location.getDistanceMeters())
       .build();
   }
 
@@ -118,6 +119,8 @@ public class LocationEncoder {
     location.setTitle(locationAvro.getTitle());
     location.setIsoCountryCode2Digit(locationAvro.getIsoCountryCode2Digit());
     location.setDistance(locationAvro.getDistance());
+    location.setDistanceMeters(locationAvro.getDistanceMeters());
+
     return location;
   }
 

--- a/geocode-api/src/test/java/org/gbif/geocode/api/model/LocationEncoderTest.java
+++ b/geocode-api/src/test/java/org/gbif/geocode/api/model/LocationEncoderTest.java
@@ -1,0 +1,114 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.gbif.geocode.api.model;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertNull;
+
+import com.fasterxml.jackson.databind.JsonNode;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import java.io.InputStream;
+import java.util.ArrayList;
+import java.util.List;
+import org.junit.jupiter.api.Test;
+
+/**
+ * Tests for {@link LocationEncoder}.0
+ */
+public class LocationEncoderTest {
+
+  private static final ObjectMapper MAPPER = new ObjectMapper();
+
+  /**
+   * Loads locations from the test JSON resource file.
+   */
+  private List<Location> loadLocations() throws Exception {
+    InputStream in = getClass().getResourceAsStream("/locations.json");
+    assertNotNull(in, "locations.json resource not found");
+    JsonNode root = MAPPER.readTree(in);
+    JsonNode locationsNode = root.get("locations");
+    List<Location> locations = new ArrayList<>();
+    for (JsonNode node : locationsNode) {
+      Location location = new Location();
+      location.setId(node.get("id").asText());
+      location.setType(node.get("type").asText());
+      location.setSource(node.get("source").asText());
+      location.setTitle(node.get("title").asText());
+      location.setIsoCountryCode2Digit(node.get("isoCountryCode2Digit").asText());
+      location.setDistance(node.get("distance").asDouble());
+      location.setDistanceMeters(node.get("distanceMeters").asDouble());
+      locations.add(location);
+    }
+    return locations;
+  }
+
+  /**
+   * Asserts the result list represents the same as the input.
+   */
+  private void verifyResult(List<Location> result) throws Exception {
+    List<Location> original = loadLocations();
+    assertNotNull(result);
+    assertEquals(10, result.size());
+    for (int i=0; i<original.size(); i++) {
+      assertEquals(original.get(i).getId(), result.get(i).getId());
+      assertEquals(original.get(i).getType(), result.get(i).getType());
+      assertNull(result.get(i).getSource()); // it is expected to be dropped
+      assertEquals(original.get(i).getTitle(), result.get(i).getTitle());
+      assertEquals(original.get(i).getIsoCountryCode2Digit(), result.get(i).getIsoCountryCode2Digit());
+      assertEquals(original.get(i).getDistance(), result.get(i).getDistance());
+      assertEquals(original.get(i).getDistanceMeters(), result.get(i).getDistanceMeters());
+    }
+  }
+
+  /**
+   * Round-trip check of encoding, calling attention to the removal of the source.
+   */
+  @Test
+  public void testEncodeDecode() throws Exception {
+    byte[] encoded = LocationEncoder.encode(loadLocations());
+    List<Location> decoded = LocationEncoder.decode(encoded);
+    verifyResult(decoded);
+  }
+
+  /**
+   * Round-trip check of encoding from bytes, calling attention to the removal of the source.
+   */
+  @Test
+  public void testEncodeDecodFromBytes() throws Exception {
+    try (InputStream in = getClass().getResourceAsStream("/locations.json")) {
+      byte[] encoded = LocationEncoder.encodeFromJsonBytes(in.readAllBytes());
+      List<Location> decoded = LocationEncoder.decode(encoded);
+      verifyResult(decoded);
+    }
+  }
+
+  /**
+   * Verify the id prefixes are extracted and recreated.
+   */
+  @Test
+  public void testIDPrefix() throws Exception {
+    Location marine = loadLocations().stream()
+        .filter(l -> l.getId().startsWith("http://marineregions.org/mrgid/"))
+        .findFirst()
+        .orElseThrow(() -> new AssertionError("No marine-regions location in test data"));
+
+    LocationAvro encoded = LocationEncoder.toAvro(marine);
+    assertEquals("8431", encoded.getId());
+    assertEquals(LocationIdPrefix.MRGID, encoded.getIdPrefix());
+
+    Location decoded = LocationEncoder.fromAvro(encoded);
+    assertEquals("http://marineregions.org/mrgid/8431", decoded.getId());
+  }
+}

--- a/geocode-api/src/test/java/org/gbif/geocode/api/model/LocationEncoderTest.java
+++ b/geocode-api/src/test/java/org/gbif/geocode/api/model/LocationEncoderTest.java
@@ -25,7 +25,7 @@ import java.util.List;
 import org.junit.jupiter.api.Test;
 
 /**
- * Tests for {@link LocationEncoder}.0
+ * Tests for {@link LocationEncoder}.
  */
 public class LocationEncoderTest {
 
@@ -35,23 +35,23 @@ public class LocationEncoderTest {
    * Loads locations from the test JSON resource file.
    */
   private List<Location> loadLocations() throws Exception {
-    InputStream in = getClass().getResourceAsStream("/locations.json");
-    assertNotNull(in, "locations.json resource not found");
-    JsonNode root = MAPPER.readTree(in);
-    JsonNode locationsNode = root.get("locations");
-    List<Location> locations = new ArrayList<>();
-    for (JsonNode node : locationsNode) {
-      Location location = new Location();
-      location.setId(node.get("id").asText());
-      location.setType(node.get("type").asText());
-      location.setSource(node.get("source").asText());
-      location.setTitle(node.get("title").asText());
-      location.setIsoCountryCode2Digit(node.get("isoCountryCode2Digit").asText());
-      location.setDistance(node.get("distance").asDouble());
-      location.setDistanceMeters(node.get("distanceMeters").asDouble());
-      locations.add(location);
+    try (InputStream in = getClass().getResourceAsStream("/locations.json")) {
+      assertNotNull(in, "locations.json resource not found");
+      JsonNode root = MAPPER.readTree(in);
+      JsonNode locationsNode = root.get("locations");
+      List<Location> locations = new ArrayList<>();
+      for (JsonNode node : locationsNode) {
+        Location location = new Location();
+        location.setId(node.get("id").asText());
+        location.setType(node.get("type").asText());
+        location.setSource(node.get("source").asText());
+        location.setTitle(node.get("title").asText());
+        location.setIsoCountryCode2Digit(node.get("isoCountryCode2Digit").asText());
+        location.setDistance(node.get("distance").asDouble());
+        locations.add(location);
+      }
+      return locations;
     }
-    return locations;
   }
 
   /**
@@ -60,7 +60,7 @@ public class LocationEncoderTest {
   private void verifyResult(List<Location> result) throws Exception {
     List<Location> original = loadLocations();
     assertNotNull(result);
-    assertEquals(10, result.size());
+    assertEquals(original.size(), result.size());
     for (int i=0; i<original.size(); i++) {
       assertEquals(original.get(i).getId(), result.get(i).getId());
       assertEquals(original.get(i).getType(), result.get(i).getType());
@@ -68,7 +68,6 @@ public class LocationEncoderTest {
       assertEquals(original.get(i).getTitle(), result.get(i).getTitle());
       assertEquals(original.get(i).getIsoCountryCode2Digit(), result.get(i).getIsoCountryCode2Digit());
       assertEquals(original.get(i).getDistance(), result.get(i).getDistance());
-      assertEquals(original.get(i).getDistanceMeters(), result.get(i).getDistanceMeters());
     }
   }
 
@@ -86,8 +85,9 @@ public class LocationEncoderTest {
    * Round-trip check of encoding from bytes, calling attention to the removal of the source.
    */
   @Test
-  public void testEncodeDecodFromBytes() throws Exception {
+  public void testEncodeDecodeFromBytes() throws Exception {
     try (InputStream in = getClass().getResourceAsStream("/locations.json")) {
+      assertNotNull(in, "locations.json resource not found");
       byte[] encoded = LocationEncoder.encodeFromJsonBytes(in.readAllBytes());
       List<Location> decoded = LocationEncoder.decode(encoded);
       verifyResult(decoded);

--- a/geocode-api/src/test/java/org/gbif/geocode/api/model/LocationEncoderTest.java
+++ b/geocode-api/src/test/java/org/gbif/geocode/api/model/LocationEncoderTest.java
@@ -48,6 +48,7 @@ public class LocationEncoderTest {
         location.setTitle(node.get("title").asText());
         location.setIsoCountryCode2Digit(node.get("isoCountryCode2Digit").asText());
         location.setDistance(node.get("distance").asDouble());
+        location.setDistanceMeters(node.get("distanceMeters").asDouble());
         locations.add(location);
       }
       return locations;
@@ -68,6 +69,7 @@ public class LocationEncoderTest {
       assertEquals(original.get(i).getTitle(), result.get(i).getTitle());
       assertEquals(original.get(i).getIsoCountryCode2Digit(), result.get(i).getIsoCountryCode2Digit());
       assertEquals(original.get(i).getDistance(), result.get(i).getDistance());
+      assertEquals(original.get(i).getDistanceMeters(), result.get(i).getDistanceMeters());
     }
   }
 

--- a/geocode-api/src/test/resources/locations.json
+++ b/geocode-api/src/test/resources/locations.json
@@ -1,0 +1,94 @@
+{
+  "locations": [
+    {
+      "id": "ECU",
+      "type": "GADM0",
+      "source": "http://gadm.org/",
+      "isoCountryCode2Digit": "EC",
+      "distance": 0.0,
+      "distanceMeters": 0.0,
+      "title": "Ecuador"
+    },
+    {
+      "id": "ECU.19_1",
+      "type": "GADM1",
+      "source": "http://gadm.org/",
+      "isoCountryCode2Digit": "EC",
+      "distance": 0.0,
+      "distanceMeters": 0.0,
+      "title": "Pichincha"
+    },
+    {
+      "id": "ECU.19.8_1",
+      "type": "GADM2",
+      "source": "http://gadm.org/",
+      "isoCountryCode2Digit": "EC",
+      "distance": 0.0,
+      "distanceMeters": 0.0,
+      "title": "San Miguel de los Bancos"
+    },
+    {
+      "id": "ECU.19.8.1_1",
+      "type": "GADM3",
+      "source": "http://gadm.org/",
+      "isoCountryCode2Digit": "EC",
+      "distance": 0.0,
+      "distanceMeters": 0.0,
+      "title": "Mindo"
+    },
+    {
+      "id": "WGSRPD:ECU-OO",
+      "type": "WGSRPD",
+      "source": "http://www.tdwg.org/standards/109",
+      "isoCountryCode2Digit": "EC",
+      "distance": 0.0,
+      "distanceMeters": 0.0,
+      "title": "Ecuador"
+    },
+    {
+      "id": "SOUTH_AMERICA",
+      "type": "Continent",
+      "source": "https://github.com/gbif/continents",
+      "isoCountryCode2Digit": "",
+      "distance": 0.0,
+      "distanceMeters": 0.0,
+      "title": "SOUTH_AMERICA"
+    },
+    {
+      "id": "http://marineregions.org/mrgid/8431",
+      "type": "Political",
+      "source": "https://www.marineregions.org/",
+      "isoCountryCode2Digit": "EC",
+      "distance": 0.0,
+      "distanceMeters": 0.0,
+      "title": "Ecuador"
+    },
+    {
+      "id": "ECU.19.8.2_1",
+      "type": "GADM3",
+      "source": "http://gadm.org/",
+      "isoCountryCode2Digit": "EC",
+      "distance": 0.038879275983394995,
+      "distanceMeters": 4327.5,
+      "title": "San Miguel De Los Bancos"
+    },
+    {
+      "id": "ECU.19.6_1",
+      "type": "GADM2",
+      "source": "http://gadm.org/",
+      "isoCountryCode2Digit": "EC",
+      "distance": 0.04057529715676165,
+      "distanceMeters": 4516.2,
+      "title": "Quito"
+    },
+    {
+      "id": "ECU.19.6.16_1",
+      "type": "GADM3",
+      "source": "http://gadm.org/",
+      "isoCountryCode2Digit": "EC",
+      "distance": 0.04057529715676165,
+      "distanceMeters": 4516.2,
+      "title": "Lloa"
+    }
+  ]
+}

--- a/pom.xml
+++ b/pom.xml
@@ -117,6 +117,7 @@
     <curator.version>5.5.0</curator.version>
     <curator-test.version>5.5.0</curator-test.version>
     <commons-lang3.version>3.20.0</commons-lang3.version>
+    <avro.version>1.11.4</avro.version>
 
     <!-- Jakarta -->
     <jakarta-validation.version>3.1.1</jakarta-validation.version>
@@ -337,7 +338,11 @@
         <artifactId>gt-referencing</artifactId>
         <version>${geotools.version}</version>
       </dependency>
-
+      <dependency>
+        <groupId>org.apache.avro</groupId>
+        <artifactId>avro</artifactId>
+        <version>${avro.version}</version>
+      </dependency>
       <dependency>
         <groupId>org.geotools</groupId>
         <artifactId>gt-opengis</artifactId>
@@ -432,7 +437,6 @@
         <groupId>org.apache.maven.plugins</groupId>
         <artifactId>maven-enforcer-plugin</artifactId>
       </plugin>
-
       <plugin>
         <groupId>org.apache.maven.plugins</groupId>
         <artifactId>maven-jar-plugin</artifactId>


### PR DESCRIPTION
This adds a utility so a user can encode and decode a `List<Location>` into an optimised `byte[]` for the purposes of lookup caches (e.g. HBase)